### PR TITLE
Move `rand` to dev deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ criterion = "0.3"
 md5 = "0.7"
 blake2 = "0.9"
 sha2 = "0.9"
+rand = "0.8"
 
 [dependencies]
 arrayvec = "0.7"
-rand = "0.8"


### PR DESCRIPTION
Projects that use this crate, don't need to depend on the `rand` dep, because this library's public interface doesn't use any types from that crate. This dep is only used for testing, and therefore it belongs to dev deps.